### PR TITLE
fix: prevent empty state flash before Triplit loads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { client } from "./triplit/client"
 const App: Component = () => {
   const [newItem, setNewItem] = createSignal("")
 
-  const { results: items, error, fetching } = useQuery(client, client.query("shopping_items"))
+  const { results: items, error, fetchingLocal } = useQuery(client, client.query("shopping_items"))
 
   const itemsArray = createMemo(() => {
     const itemsMap = items()
@@ -91,7 +91,7 @@ const App: Component = () => {
               )}
             </For>
 
-            {!fetching() && itemsArray().length === 0 && (
+            {!fetchingLocal() && itemsArray().length === 0 && (
               <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
             )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,57 +53,61 @@ const App: Component = () => {
       <div class="max-w-md mx-auto py-8 px-4">
         <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">🐦 Shopping Bird</h1>
 
-        <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-          <div class="flex gap-2 mb-4">
-            <input
-              type="text"
-              value={newItem()}
-              onInput={(e) => setNewItem(e.currentTarget.value)}
-              onKeyPress={(e) => e.key === "Enter" && addItem()}
-              placeholder="Add a shopping item..."
-              class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <button
-              onClick={addItem}
-              class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
-              Add
-            </button>
-          </div>
+        {!fetchingLocal() && (
+          <>
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+              <div class="flex gap-2 mb-4">
+                <input
+                  type="text"
+                  value={newItem()}
+                  onInput={(e) => setNewItem(e.currentTarget.value)}
+                  onKeyPress={(e) => e.key === "Enter" && addItem()}
+                  placeholder="Add a shopping item..."
+                  class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button
+                  onClick={addItem}
+                  class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  Add
+                </button>
+              </div>
 
-          <div class="space-y-2">
-            <For each={itemsArray()}>
-              {(item) => (
-                <div class="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
-                  <input
-                    type="checkbox"
-                    checked={item.completed}
-                    onChange={() => toggleItem(item.id)}
-                    class="w-4 h-4 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span class={`flex-1 ${item.completed ? "line-through text-gray-500" : "text-gray-800"}`}>
-                    {item.text}
-                  </span>
-                  <button onClick={() => removeItem(item.id)} class="text-red-500 hover:text-red-700 text-sm">
-                    Remove
-                  </button>
-                </div>
-              )}
-            </For>
+              <div class="space-y-2">
+                <For each={itemsArray()}>
+                  {(item) => (
+                    <div class="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
+                      <input
+                        type="checkbox"
+                        checked={item.completed}
+                        onChange={() => toggleItem(item.id)}
+                        class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span class={`flex-1 ${item.completed ? "line-through text-gray-500" : "text-gray-800"}`}>
+                        {item.text}
+                      </span>
+                      <button onClick={() => removeItem(item.id)} class="text-red-500 hover:text-red-700 text-sm">
+                        Remove
+                      </button>
+                    </div>
+                  )}
+                </For>
 
-            {!fetchingLocal() && itemsArray().length === 0 && (
-              <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
-            )}
+                {itemsArray().length === 0 && (
+                  <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
+                )}
 
-            {error() && (
-              <p class="text-red-500 text-center py-4">Error loading items: {error()?.message || "Unknown error"}</p>
-            )}
-          </div>
-        </div>
+                {error() && (
+                  <p class="text-red-500 text-center py-4">Error loading items: {error()?.message || "Unknown error"}</p>
+                )}
+              </div>
+            </div>
 
-        <div class="text-center text-sm text-gray-500">
-          <p>Offline first • Syncs with Google Keep</p>
-        </div>
+            <div class="text-center text-sm text-gray-500">
+              <p>Offline first • Syncs with Google Keep</p>
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,57 +53,61 @@ const App: Component = () => {
       <div class="max-w-md mx-auto py-8 px-4">
         <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">🐦 Shopping Bird</h1>
 
-            <div class={`bg-white rounded-lg shadow-md p-6 mb-6 transition-opacity duration-300 ${fetchingLocal() ? 'opacity-0' : 'opacity-100'}`}>
-              <div class="flex gap-2 mb-4">
-                <input
-                  type="text"
-                  value={newItem()}
-                  onInput={(e) => setNewItem(e.currentTarget.value)}
-                  onKeyPress={(e) => e.key === "Enter" && addItem()}
-                  placeholder="Add a shopping item..."
-                  class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <button
-                  onClick={addItem}
-                  class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  Add
-                </button>
-              </div>
+        <div
+          class={`bg-white rounded-lg shadow-md p-6 mb-6 transition-opacity duration-200 ${fetchingLocal() ? "opacity-0" : "opacity-100"}`}
+        >
+          <div class="flex gap-2 mb-4">
+            <input
+              type="text"
+              value={newItem()}
+              onInput={(e) => setNewItem(e.currentTarget.value)}
+              onKeyPress={(e) => e.key === "Enter" && addItem()}
+              placeholder="Add a shopping item..."
+              class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              onClick={addItem}
+              class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              Add
+            </button>
+          </div>
 
-              <div class="space-y-2">
-                <For each={itemsArray()}>
-                  {(item) => (
-                    <div class="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
-                      <input
-                        type="checkbox"
-                        checked={item.completed}
-                        onChange={() => toggleItem(item.id)}
-                        class="w-4 h-4 text-blue-600 focus:ring-blue-500"
-                      />
-                      <span class={`flex-1 ${item.completed ? "line-through text-gray-500" : "text-gray-800"}`}>
-                        {item.text}
-                      </span>
-                      <button onClick={() => removeItem(item.id)} class="text-red-500 hover:text-red-700 text-sm">
-                        Remove
-                      </button>
-                    </div>
-                  )}
-                </For>
+          <div class="space-y-2">
+            <For each={itemsArray()}>
+              {(item) => (
+                <div class="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
+                  <input
+                    type="checkbox"
+                    checked={item.completed}
+                    onChange={() => toggleItem(item.id)}
+                    class="w-4 h-4 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span class={`flex-1 ${item.completed ? "line-through text-gray-500" : "text-gray-800"}`}>
+                    {item.text}
+                  </span>
+                  <button onClick={() => removeItem(item.id)} class="text-red-500 hover:text-red-700 text-sm">
+                    Remove
+                  </button>
+                </div>
+              )}
+            </For>
 
-                {itemsArray().length === 0 && (
-                  <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
-                )}
+            {itemsArray().length === 0 && (
+              <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
+            )}
 
-                {error() && (
-                  <p class="text-red-500 text-center py-4">Error loading items: {error()?.message || "Unknown error"}</p>
-                )}
-              </div>
-            </div>
+            {error() && (
+              <p class="text-red-500 text-center py-4">Error loading items: {error()?.message || "Unknown error"}</p>
+            )}
+          </div>
+        </div>
 
-            <div class={`text-center text-sm text-gray-500 transition-opacity duration-300 ${fetchingLocal() ? 'opacity-0' : 'opacity-100'}`}>
-              <p>Offline first • Syncs with Google Keep</p>
-            </div>
+        <div
+          class={`text-center text-sm text-gray-500 transition-opacity duration-200 ${fetchingLocal() ? "opacity-0" : "opacity-100"}`}
+        >
+          <p>Offline first • Syncs with Google Keep</p>
+        </div>
       </div>
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,9 +53,7 @@ const App: Component = () => {
       <div class="max-w-md mx-auto py-8 px-4">
         <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">🐦 Shopping Bird</h1>
 
-        {!fetchingLocal() && (
-          <>
-            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+            <div class={`bg-white rounded-lg shadow-md p-6 mb-6 transition-opacity duration-300 ${fetchingLocal() ? 'opacity-0' : 'opacity-100'}`}>
               <div class="flex gap-2 mb-4">
                 <input
                   type="text"
@@ -103,11 +101,9 @@ const App: Component = () => {
               </div>
             </div>
 
-            <div class="text-center text-sm text-gray-500">
+            <div class={`text-center text-sm text-gray-500 transition-opacity duration-300 ${fetchingLocal() ? 'opacity-0' : 'opacity-100'}`}>
               <p>Offline first • Syncs with Google Keep</p>
             </div>
-          </>
-        )}
       </div>
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { client } from "./triplit/client"
 const App: Component = () => {
   const [newItem, setNewItem] = createSignal("")
 
-  const { results: items, error } = useQuery(client, client.query("shopping_items"))
+  const { results: items, error, fetching } = useQuery(client, client.query("shopping_items"))
 
   const itemsArray = createMemo(() => {
     const itemsMap = items()
@@ -91,7 +91,7 @@ const App: Component = () => {
               )}
             </For>
 
-            {itemsArray().length === 0 && (
+            {!fetching() && itemsArray().length === 0 && (
               <p class="text-gray-500 text-center py-8">No items yet. Add your first shopping item above!</p>
             )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,8 @@ const App: Component = () => {
         <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">🐦 Shopping Bird</h1>
 
         <div
-          class={`bg-white rounded-lg shadow-md p-6 mb-6 transition-opacity duration-200 ${fetchingLocal() ? "opacity-0" : "opacity-100"}`}
+          class="bg-white rounded-lg shadow-md p-6 mb-6 transition-opacity duration-200 data-[loading=true]:opacity-0 data-[loading=false]:opacity-100"
+          data-loading={fetchingLocal()}
         >
           <div class="flex gap-2 mb-4">
             <input
@@ -104,7 +105,8 @@ const App: Component = () => {
         </div>
 
         <div
-          class={`text-center text-sm text-gray-500 transition-opacity duration-200 ${fetchingLocal() ? "opacity-0" : "opacity-100"}`}
+          class="text-center text-sm text-gray-500 transition-opacity duration-200 data-[loading=true]:opacity-0 data-[loading=false]:opacity-100"
+          data-loading={fetchingLocal()}
         >
           <p>Offline first • Syncs with Google Keep</p>
         </div>


### PR DESCRIPTION
Only show empty state message after Triplit finishes loading by checking the fetching state. This prevents the flash of "No items yet" text that appears before local data is loaded from IndexedDB.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)